### PR TITLE
【CM】【Lambda】【データINSERT用】【InsertDB】【M】ユースケースのための準備 #87

### DIFF
--- a/code/cardApiCall/infoInsert/repository/card.go
+++ b/code/cardApiCall/infoInsert/repository/card.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	"atomisu.com/ocg-statics/infoInsert/sqlc_gen"
@@ -12,6 +13,8 @@ type CardRepository interface {
 	Repository
 	GetCardByID(ctx context.Context, cardId int64) (sqlc_gen.Card, error)
 	InsertCard(ctx context.Context, arg sqlc_gen.InsertCardParams) (sqlc_gen.Card, error)
+	GetCardByNameEn(ctx context.Context, nameEn string) (sqlc_gen.Card, error)
+	GetCardByNameJa(ctx context.Context, nameJa string) (sqlc_gen.Card, error)
 }
 
 type cardRepositoryImpl struct {
@@ -54,5 +57,33 @@ func (r *cardRepositoryImpl) InsertCard(ctx context.Context, arg sqlc_gen.Insert
 	}
 
 	r.logDBResult("InsertCard", card, zap.Int64("card_id", arg.OcgApiID.Int64))
+	return card, nil
+}
+
+func (r *cardRepositoryImpl) GetCardByNameEn(ctx context.Context, nameEn string) (sqlc_gen.Card, error) {
+	start := time.Now()
+	defer r.logDBOperation("GetCardByNameEn", start, zap.String("name_en", nameEn))
+
+	card, err := r.queries.SelectByCardNameEn(ctx, sql.NullString{String: nameEn, Valid: true})
+	if err != nil {
+		r.logDBError("GetCardByNameEn", err, zap.String("name_en", nameEn))
+		return sqlc_gen.Card{}, err
+	}
+
+	r.logDBResult("GetCardByNameEn", card, zap.String("name_en", nameEn))
+	return card, nil
+}
+
+func (r *cardRepositoryImpl) GetCardByNameJa(ctx context.Context, nameJa string) (sqlc_gen.Card, error) {
+	start := time.Now()
+	defer r.logDBOperation("GetCardByNameJa", start, zap.String("name_ja", nameJa))
+
+	card, err := r.queries.SelectByCardNameJa(ctx, sql.NullString{String: nameJa, Valid: true})
+	if err != nil {
+		r.logDBError("GetCardByNameJa", err, zap.String("name_ja", nameJa))
+		return sqlc_gen.Card{}, err
+	}
+
+	r.logDBResult("GetCardByNameJa", card, zap.String("name_ja", nameJa))
 	return card, nil
 }

--- a/code/cardApiCall/infoInsert/sqlc/queries/card.sql
+++ b/code/cardApiCall/infoInsert/sqlc/queries/card.sql
@@ -40,3 +40,11 @@ WHERE id = $1;
 -- name: SelectByCardId :one
 SELECT * FROM cards
 WHERE id = $1;
+
+-- name: SelectByCardNameEn :one
+SELECT * FROM cards
+WHERE name_en = $1;
+
+-- name: SelectByCardNameJa :one
+SELECT * FROM cards
+WHERE name_ja = $1;

--- a/code/cardApiCall/infoInsert/sqlc_gen/card.sql_gen.go
+++ b/code/cardApiCall/infoInsert/sqlc_gen/card.sql_gen.go
@@ -168,6 +168,56 @@ func (q *Queries) SelectByCardId(ctx context.Context, id int64) (Card, error) {
 	return i, err
 }
 
+const selectByCardNameEn = `-- name: SelectByCardNameEn :one
+SELECT id, neuron_id, ocg_api_id, name_ja, name_en, card_text_ja, card_text_en, dataowner, regist_date, enable_start_date, enable_end_date, version FROM cards
+WHERE name_en = $1
+`
+
+func (q *Queries) SelectByCardNameEn(ctx context.Context, nameEn sql.NullString) (Card, error) {
+	row := q.db.QueryRowContext(ctx, selectByCardNameEn, nameEn)
+	var i Card
+	err := row.Scan(
+		&i.ID,
+		&i.NeuronID,
+		&i.OcgApiID,
+		&i.NameJa,
+		&i.NameEn,
+		&i.CardTextJa,
+		&i.CardTextEn,
+		&i.Dataowner,
+		&i.RegistDate,
+		&i.EnableStartDate,
+		&i.EnableEndDate,
+		&i.Version,
+	)
+	return i, err
+}
+
+const selectByCardNameJa = `-- name: SelectByCardNameJa :one
+SELECT id, neuron_id, ocg_api_id, name_ja, name_en, card_text_ja, card_text_en, dataowner, regist_date, enable_start_date, enable_end_date, version FROM cards
+WHERE name_ja = $1
+`
+
+func (q *Queries) SelectByCardNameJa(ctx context.Context, nameJa sql.NullString) (Card, error) {
+	row := q.db.QueryRowContext(ctx, selectByCardNameJa, nameJa)
+	var i Card
+	err := row.Scan(
+		&i.ID,
+		&i.NeuronID,
+		&i.OcgApiID,
+		&i.NameJa,
+		&i.NameEn,
+		&i.CardTextJa,
+		&i.CardTextEn,
+		&i.Dataowner,
+		&i.RegistDate,
+		&i.EnableStartDate,
+		&i.EnableEndDate,
+		&i.Version,
+	)
+	return i, err
+}
+
 const updateCard = `-- name: UpdateCard :one
 UPDATE cards
 SET

--- a/code/cardApiCall/infoInsert/usecase/neon/neon_base.go
+++ b/code/cardApiCall/infoInsert/usecase/neon/neon_base.go
@@ -20,6 +20,9 @@ type NeonUseCase interface {
 	GetTrapCardByID(ctx context.Context, cardID int64) (cardrecord.TrapCardSelectResult, error)
 	InsertSpellCardInfo(ctx context.Context, cardInfo cardrecord.StandardCard) (int64, error)
 	GetSpellCardByID(ctx context.Context, cardID int64) (cardrecord.SpellCardSelectResult, error)
+	InsertMonsterCardInfo(ctx context.Context, cardInfo cardrecord.StandardCard) (int64, error)
+	GetMonsterCardByID(ctx context.Context, cardID int64) (cardrecord.MonsterCardSelectResult, error)
+	GetMonsterTypeLinesEnByCardID(ctx context.Context, cardID int64) ([]string, error)
 }
 
 // NewNeonUseCase は、NeonUseCaseのコンストラクタです。

--- a/code/cardApiCall/infoInsert/usecase/neon/neon_monster.go
+++ b/code/cardApiCall/infoInsert/usecase/neon/neon_monster.go
@@ -1,0 +1,106 @@
+package neon
+
+import (
+	"context"
+	"fmt"
+
+	"atomisu.com/ocg-statics/infoInsert/dto/cardrecord"
+	"atomisu.com/ocg-statics/infoInsert/repository"
+	"atomisu.com/ocg-statics/infoInsert/sqlc_gen"
+	"atomisu.com/ocg-statics/infoInsert/transaction"
+)
+
+// InsertMonsterCardInfoはStandardCardを引数として、適切なテーブル群に必要なレコードを挿入する
+func (n *neonUseCaseImpl) InsertMonsterCardInfo(ctx context.Context, cardInfo cardrecord.StandardCard) (int64, error) {
+	tr := transaction.NewTx(n.ProduceConnDB())
+
+	result := int64(0)
+
+	err := tr.ExecTx(ctx, func(q *sqlc_gen.Queries) error {
+		// リポジトリの準備
+		cardRepo := repository.NewCardRepository(q)
+		monsterRepo := repository.NewMonsterRepository(q)
+
+		// カードの挿入
+		card, err := cardRepo.InsertCard(ctx, cardInfo.ToInsertCardParamsExceptMonster())
+		if err != nil {
+			return fmt.Errorf("error create card %w", err)
+		}
+
+		raceId := int32(9)      // TODO
+		attributeId := int32(1) // TODO
+		typeIds := []int32{1}   // TODO
+
+		// モンスターの挿入
+		_, err = monsterRepo.InsertMonster(ctx, card.ID, raceId, attributeId, cardInfo.Atk, cardInfo.Def, cardInfo.Level, typeIds)
+		if err != nil {
+			return fmt.Errorf("error create monster %w", err)
+		}
+
+		result = card.ID
+		return nil
+	})
+
+	return result, err
+}
+
+// GetMonsterCardByID は、モンスターのカードを取得。
+func (n *neonUseCaseImpl) GetMonsterCardByID(ctx context.Context, cardID int64) (cardrecord.MonsterCardSelectResult, error) {
+	monsterRepo := repository.NewMonsterRepository(sqlc_gen.New(n.ProduceConnDB()))
+	return monsterRepo.GetMonsterByCardID(ctx, cardID)
+}
+
+// GetMonsterTypeLinesEnByCardID は、モンスターの種類を取得。
+func (n *neonUseCaseImpl) GetMonsterTypeLinesEnByCardID(ctx context.Context, cardID int64) ([]string, error) {
+	monsterRepo := repository.NewMonsterRepository(sqlc_gen.New(n.ProduceConnDB()))
+	typeLineNames := []string{}
+	typeLineSelectResult, err := monsterRepo.GetMonsterTypeLineByCardID(ctx, cardID)
+	if err != nil {
+		return nil, err
+	}
+
+	if typeLineSelectResult.IsNormal {
+		typeLineNames = append(typeLineNames, "Normal")
+	}
+	if typeLineSelectResult.IsEffect {
+		typeLineNames = append(typeLineNames, "Effect")
+	}
+	if typeLineSelectResult.IsToon {
+		typeLineNames = append(typeLineNames, "Toon")
+	}
+	if typeLineSelectResult.IsSpirit {
+		typeLineNames = append(typeLineNames, "Spirit")
+	}
+	if typeLineSelectResult.IsUnion {
+		typeLineNames = append(typeLineNames, "Union")
+	}
+	if typeLineSelectResult.IsDual {
+		typeLineNames = append(typeLineNames, "Dual")
+	}
+	if typeLineSelectResult.IsTuner {
+		typeLineNames = append(typeLineNames, "Tuner")
+	}
+	if typeLineSelectResult.IsReverse {
+		typeLineNames = append(typeLineNames, "Reverse")
+	}
+	if typeLineSelectResult.IsRitual {
+		typeLineNames = append(typeLineNames, "Ritual")
+	}
+	if typeLineSelectResult.IsXyz {
+		typeLineNames = append(typeLineNames, "Xyz")
+	}
+	if typeLineSelectResult.IsSynchro {
+		typeLineNames = append(typeLineNames, "Synchro")
+	}
+	if typeLineSelectResult.IsFusion {
+		typeLineNames = append(typeLineNames, "Fusion")
+	}
+	if typeLineSelectResult.IsLink {
+		typeLineNames = append(typeLineNames, "Link")
+	}
+	if typeLineSelectResult.IsPendulum {
+		typeLineNames = append(typeLineNames, "Pendulum")
+	}
+
+	return typeLineNames, nil
+}

--- a/code/cardApiCall/infoInsert/usecase/neon/neon_monster_test.go
+++ b/code/cardApiCall/infoInsert/usecase/neon/neon_monster_test.go
@@ -1,0 +1,86 @@
+package neon_test
+
+import (
+	"context"
+	"testing"
+
+	"atomisu.com/ocg-statics/infoInsert/app"
+	"atomisu.com/ocg-statics/infoInsert/config"
+	"atomisu.com/ocg-statics/infoInsert/dto/cardrecord"
+	"atomisu.com/ocg-statics/infoInsert/usecase/neon"
+	"github.com/samber/do"
+	"github.com/stretchr/testify/assert"
+)
+
+func testMonsterCommon(t *testing.T, sampleData cardrecord.StandardCard, attrNameJa string, raceNameJa string, typeLines []string) (cardrecord.MonsterCardSelectResult, error) {
+	config.BeforeEachForUnitTest()      // テスト前処理
+	defer config.AfterEachForUnitTest() // テスト後処理
+
+	injector := app.SetupDIContainer()
+	do.Override(injector, config.TestDbConnection)
+
+	neonUseCase := do.MustInvoke[neon.NeonUseCase](injector)
+
+	resultInsert, err := neonUseCase.InsertMonsterCardInfo(context.Background(), sampleData)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resultInsert)
+	assert.NotEqual(t, int32(-1), resultInsert)
+	cardID := resultInsert
+
+	resultsGet, err := neonUseCase.GetMonsterCardByID(context.Background(), cardID)
+	assert.NoError(t, err)
+	assert.NotNil(t, resultsGet)
+	assert.Equal(t, sampleData.NameEn, resultsGet.NameEn)
+	assert.Equal(t, sampleData.NameJa, resultsGet.NameJa)
+	assert.Equal(t, sampleData.DescEn, resultsGet.CardTextEn)
+	assert.Equal(t, sampleData.DescJa, resultsGet.CardTextJa)
+	assert.Equal(t, sampleData.NeuronID, resultsGet.NeuronID)
+	assert.Equal(t, sampleData.TcgID, resultsGet.OcgApiID)
+	assert.Equal(t, raceNameJa, resultsGet.RaceNameJa)
+	assert.Equal(t, attrNameJa, resultsGet.AttributeNameJa)
+	assert.Equal(t, sampleData.Def, resultsGet.Defense)
+	assert.Equal(t, sampleData.Atk, resultsGet.Attack)
+	assert.Equal(t, sampleData.Level, resultsGet.Level)
+
+	typeLinesEn, err := neonUseCase.GetMonsterTypeLinesEnByCardID(context.Background(), cardID)
+	assert.NoError(t, err)
+	assert.NotNil(t, typeLinesEn)
+	assert.Equal(t, typeLines, typeLinesEn)
+
+	return resultsGet, nil
+}
+
+func TestNeonMonsterUseCase(t *testing.T) {
+	t.Run("カード情報の挿入&取得テスト（通常モンスター）", func(t *testing.T) {
+		sampleData := cardrecord.StandardCard{
+			NameEn:         "Mokey Mokey",
+			NameJa:         "もけもけ",
+			DescEn:         "An outcast angel.",
+			DescJa:         "天使のはみだし者",
+			NeuronID:       6018,
+			TcgID:          27288416,
+			Def:            100,
+			Atk:            300,
+			Type:           "Normal Monster",
+			Level:          1,
+			Race:           "Fairy",
+			LinkMarkers:    []string{},
+			Attribute:      "LIGHT",
+			LinkVal:        0,
+			TypeLines:      []string{"Normal"},
+			PendulumScale:  0,
+			PendulumTextJa: "",
+			PendulumTextEn: "",
+		}
+
+		AttributeNameJa := "光"
+		RaceNameJa := "天使族"
+		TypeLines := []string{"Normal"}
+
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
+
+	})
+}


### PR DESCRIPTION
- 英名、和名指定でカードを取得するクエリを追加
- カードリポジトリに英名、和名指定でカードを取得するロジックを追加
- モンスターユースケースのテストを整備
- モンスターユースケースに複数メソッドを実装