### PR TITLE
【CM】【Lambda】【データINSERT用】【InsertDB】【M】特性持ちモンスター挿入_ユースケースの完成#76

### DIFF
--- a/code/cardApiCall/infoInsert/repository/monster_type.go
+++ b/code/cardApiCall/infoInsert/repository/monster_type.go
@@ -45,10 +45,16 @@ func (r *monsterTypeRepositoryImpl) GetMonsterTypeByNameJa(ctx context.Context, 
 		return k, err
 	}
 
+	// 0件の場合は、空を返す
+	if len(monsterType) == 0 {
+		return k, nil
+	}
+
+	// 1つ目の要素のみ取得
 	row := kind.SelectFullKindInfoRow{
-		ID:     monsterType.ID,
-		NameJa: monsterType.NameJa,
-		NameEn: monsterType.NameEn,
+		ID:     monsterType[0].ID,
+		NameJa: monsterType[0].NameJa,
+		NameEn: monsterType[0].NameEn,
 	}
 
 	return kind.MonsterKind{Kind: k.FromSelectFullKindInfoRow(row)}, nil
@@ -66,10 +72,16 @@ func (r *monsterTypeRepositoryImpl) GetMonsterTypeByNameEn(ctx context.Context, 
 		return k, err
 	}
 
+	// 0件の場合は、空を返す
+	if len(monsterType) == 0 {
+		return k, nil
+	}
+
+	// 1つ目の要素のみ取得
 	row := kind.SelectFullKindInfoRow{
-		ID:     monsterType.ID,
-		NameJa: monsterType.NameJa,
-		NameEn: monsterType.NameEn,
+		ID:     monsterType[0].ID,
+		NameJa: monsterType[0].NameJa,
+		NameEn: monsterType[0].NameEn,
 	}
 
 	return kind.MonsterKind{Kind: k.FromSelectFullKindInfoRow(row)}, nil

--- a/code/cardApiCall/infoInsert/repository/monster_type.go
+++ b/code/cardApiCall/infoInsert/repository/monster_type.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	"atomisu.com/ocg-statics/infoInsert/dto/kind"
@@ -50,6 +51,11 @@ func (r *monsterTypeRepositoryImpl) GetMonsterTypeByNameJa(ctx context.Context, 
 		return k, nil
 	}
 
+	// 複数件は想定外なのでエラーにする（必要なら先頭採用に変更）
+	if len(monsterType) > 1 {
+		return k, fmt.Errorf("multiple monster_types found (name_ja=%v): count=%d", nameJa, len(monsterType))
+	}
+
 	// 1つ目の要素のみ取得
 	row := kind.SelectFullKindInfoRow{
 		ID:     monsterType[0].ID,
@@ -75,6 +81,11 @@ func (r *monsterTypeRepositoryImpl) GetMonsterTypeByNameEn(ctx context.Context, 
 	// 0件の場合は、空を返す
 	if len(monsterType) == 0 {
 		return k, nil
+	}
+
+	// 複数件は想定外なのでエラーにする（必要なら先頭採用に変更）
+	if len(monsterType) > 1 {
+		return k, fmt.Errorf("multiple monster_types found (name_en=%v): count=%d", nameEn, len(monsterType))
 	}
 
 	// 1つ目の要素のみ取得

--- a/code/cardApiCall/infoInsert/sqlc/queries/monster_type.sql
+++ b/code/cardApiCall/infoInsert/sqlc/queries/monster_type.sql
@@ -1,10 +1,10 @@
--- name: SelectMonsterTypesByNameEn :one
+-- name: SelectMonsterTypesByNameEn :many
 -- SelectMonsterTypesByNameEn ...
 SELECT id, name_ja, name_en
 FROM monster_types
 WHERE name_en = $1;
 
--- name: SelectMonsterTypesByNameJa :one
+-- name: SelectMonsterTypesByNameJa :many
 -- SelectMonsterTypesByNameJa ...
 SELECT id, name_ja, name_en
 FROM monster_types

--- a/code/cardApiCall/infoInsert/sqlc_gen/monster_type.sql_gen.go
+++ b/code/cardApiCall/infoInsert/sqlc_gen/monster_type.sql_gen.go
@@ -30,7 +30,7 @@ func (q *Queries) SelectMonsterTypesById(ctx context.Context, id int32) (SelectM
 	return i, err
 }
 
-const selectMonsterTypesByNameEn = `-- name: SelectMonsterTypesByNameEn :one
+const selectMonsterTypesByNameEn = `-- name: SelectMonsterTypesByNameEn :many
 SELECT id, name_ja, name_en
 FROM monster_types
 WHERE name_en = $1
@@ -43,14 +43,30 @@ type SelectMonsterTypesByNameEnRow struct {
 }
 
 // SelectMonsterTypesByNameEn ...
-func (q *Queries) SelectMonsterTypesByNameEn(ctx context.Context, nameEn sql.NullString) (SelectMonsterTypesByNameEnRow, error) {
-	row := q.db.QueryRowContext(ctx, selectMonsterTypesByNameEn, nameEn)
-	var i SelectMonsterTypesByNameEnRow
-	err := row.Scan(&i.ID, &i.NameJa, &i.NameEn)
-	return i, err
+func (q *Queries) SelectMonsterTypesByNameEn(ctx context.Context, nameEn sql.NullString) ([]SelectMonsterTypesByNameEnRow, error) {
+	rows, err := q.db.QueryContext(ctx, selectMonsterTypesByNameEn, nameEn)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SelectMonsterTypesByNameEnRow
+	for rows.Next() {
+		var i SelectMonsterTypesByNameEnRow
+		if err := rows.Scan(&i.ID, &i.NameJa, &i.NameEn); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
-const selectMonsterTypesByNameJa = `-- name: SelectMonsterTypesByNameJa :one
+const selectMonsterTypesByNameJa = `-- name: SelectMonsterTypesByNameJa :many
 SELECT id, name_ja, name_en
 FROM monster_types
 WHERE name_ja = $1
@@ -63,9 +79,25 @@ type SelectMonsterTypesByNameJaRow struct {
 }
 
 // SelectMonsterTypesByNameJa ...
-func (q *Queries) SelectMonsterTypesByNameJa(ctx context.Context, nameJa sql.NullString) (SelectMonsterTypesByNameJaRow, error) {
-	row := q.db.QueryRowContext(ctx, selectMonsterTypesByNameJa, nameJa)
-	var i SelectMonsterTypesByNameJaRow
-	err := row.Scan(&i.ID, &i.NameJa, &i.NameEn)
-	return i, err
+func (q *Queries) SelectMonsterTypesByNameJa(ctx context.Context, nameJa sql.NullString) ([]SelectMonsterTypesByNameJaRow, error) {
+	rows, err := q.db.QueryContext(ctx, selectMonsterTypesByNameJa, nameJa)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SelectMonsterTypesByNameJaRow
+	for rows.Next() {
+		var i SelectMonsterTypesByNameJaRow
+		if err := rows.Scan(&i.ID, &i.NameJa, &i.NameEn); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }

--- a/code/cardApiCall/infoInsert/usecase/neon/neon_monster_test.go
+++ b/code/cardApiCall/infoInsert/usecase/neon/neon_monster_test.go
@@ -47,7 +47,7 @@ func testMonsterCommon(t *testing.T, sampleData cardrecord.StandardCard, attrNam
 	typeLinesEn, err := neonUseCase.GetMonsterTypeLinesEnByCardID(context.Background(), cardID)
 	assert.NoError(t, err)
 	assert.NotNil(t, typeLinesEn)
-	assert.Equal(t, typeLines, typeLinesEn)
+	assert.ElementsMatch(t, typeLines, typeLinesEn)
 
 	return resultsGet, nil
 }
@@ -140,13 +140,9 @@ func TestNeonMonsterUseCase(t *testing.T) {
 		AttributeNameJa := "光"
 		RaceNameJa := "炎族"
 		TypeLines := []string{"Effect"}
-		fmt.Println(sampleData)
-		fmt.Println(AttributeNameJa)
-		fmt.Println(RaceNameJa)
-		fmt.Println(TypeLines)
-		//results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
-		//assert.NoError(t, err)
-		//assert.NotNil(t, results)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
 	})
 
 	t.Run("カード情報の挿入&取得テスト（デュアル）", func(t *testing.T) {
@@ -174,13 +170,9 @@ func TestNeonMonsterUseCase(t *testing.T) {
 		AttributeNameJa := "光"
 		RaceNameJa := "戦士族"
 		TypeLines := []string{"Gemini", "Effect"}
-		fmt.Println(sampleData)
-		fmt.Println(AttributeNameJa)
-		fmt.Println(RaceNameJa)
-		fmt.Println(TypeLines)
-		//results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
-		//assert.NoError(t, err)
-		//assert.NotNil(t, results)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
 	})
 
 	t.Run("カード情報の挿入&取得テスト（トゥーン）", func(t *testing.T) {
@@ -208,13 +200,9 @@ func TestNeonMonsterUseCase(t *testing.T) {
 		AttributeNameJa := "闇"
 		RaceNameJa := "機械族"
 		TypeLines := []string{"Toon", "Effect"}
-		fmt.Println(sampleData)
-		fmt.Println(AttributeNameJa)
-		fmt.Println(RaceNameJa)
-		fmt.Println(TypeLines)
-		//results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
-		//assert.NoError(t, err)
-		//assert.NotNil(t, results)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
 	})
 
 	t.Run("カード情報の挿入&取得テスト（効果チューナー）", func(t *testing.T) {
@@ -242,13 +230,9 @@ func TestNeonMonsterUseCase(t *testing.T) {
 		AttributeNameJa := "風"
 		RaceNameJa := "幻竜族"
 		TypeLines := []string{"Tuner", "Effect"}
-		fmt.Println(sampleData)
-		fmt.Println(AttributeNameJa)
-		fmt.Println(RaceNameJa)
-		fmt.Println(TypeLines)
-		//results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
-		//assert.NoError(t, err)
-		//assert.NotNil(t, results)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
 	})
 	t.Run("カード情報の挿入&取得テスト（ユニオン）", func(t *testing.T) {
 		sampleData := cardrecord.StandardCard{
@@ -275,13 +259,9 @@ func TestNeonMonsterUseCase(t *testing.T) {
 		AttributeNameJa := "風"
 		RaceNameJa := "天使族"
 		TypeLines := []string{"Union", "Effect"}
-		fmt.Println(sampleData)
-		fmt.Println(AttributeNameJa)
-		fmt.Println(RaceNameJa)
-		fmt.Println(TypeLines)
-		//results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
-		//assert.NoError(t, err)
-		//assert.NotNil(t, results)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
 	})
 
 	t.Run("カード情報の挿入&取得テスト（リバース）", func(t *testing.T) {
@@ -309,13 +289,9 @@ func TestNeonMonsterUseCase(t *testing.T) {
 		AttributeNameJa := "地"
 		RaceNameJa := "岩石族"
 		TypeLines := []string{"Flip", "Effect"}
-		fmt.Println(sampleData)
-		fmt.Println(AttributeNameJa)
-		fmt.Println(RaceNameJa)
-		fmt.Println(TypeLines)
-		//results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
-		//assert.NoError(t, err)
-		//assert.NotNil(t, results)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
 	})
 
 	t.Run("カード情報の挿入&取得テスト（リバースチューナー）", func(t *testing.T) {
@@ -343,13 +319,9 @@ func TestNeonMonsterUseCase(t *testing.T) {
 		AttributeNameJa := "闇"
 		RaceNameJa := "魔法使い族"
 		TypeLines := []string{"Flip", "Tuner", "Effect"}
-		fmt.Println(sampleData)
-		fmt.Println(AttributeNameJa)
-		fmt.Println(RaceNameJa)
-		fmt.Println(TypeLines)
-		//results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
-		//assert.NoError(t, err)
-		//assert.NotNil(t, results)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
 	})
 	t.Run("カード情報の挿入&取得テスト（スピリット）", func(t *testing.T) {
 		sampleData := cardrecord.StandardCard{
@@ -376,15 +348,13 @@ func TestNeonMonsterUseCase(t *testing.T) {
 		AttributeNameJa := "地"
 		RaceNameJa := "アンデット族"
 		TypeLines := []string{"Spirit", "Effect"}
-		fmt.Println(sampleData)
-		fmt.Println(AttributeNameJa)
-		fmt.Println(RaceNameJa)
-		fmt.Println(TypeLines)
-		//results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
-		//assert.NoError(t, err)
-		//assert.NotNil(t, results)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
 	})
 
+}
+func TestNeonMonsterUseCase2(t *testing.T) {
 	t.Run("カード情報の挿入&取得テスト（融合バニラ）", func(t *testing.T) {
 		sampleData := cardrecord.StandardCard{
 			NameEn:         "Karbonala Warrior",


### PR DESCRIPTION
- リポジトリのメソッドをone -> manyに変更
- DB問い合わせ時に無効な英名で検索してもエラーが出ないように
- テストを解放
- Array比較時にEqualではなくElementsMatchを使用するように変更