### PR TITLE
【CM】【Lambda】【データINSERT用】【InsertDB】【M】L挿入ユースケース作成 #100

### DIFF
--- a/code/cardApiCall/infoInsert/dto/cardrecord/monster.go
+++ b/code/cardApiCall/infoInsert/dto/cardrecord/monster.go
@@ -19,6 +19,14 @@ type MonsterCardSelectResult struct {
 	AttributeNameEn string   `db:"attribute_name_en" json:"attributeNameEn"`
 }
 
+type MonsterCardSelectResultExtended struct {
+	MonsterCardSelectResult
+	LinkMarker     int32  `db:"link_marker" json:"linkMarker"`
+	Scale          int32  `db:"scale" json:"scale"`
+	PendulumTextJa string `db:"pendulum_text_ja" json:"pendulumTextJa"`
+	PendulumTextEn string `db:"pendulum_text_en" json:"pendulumTextEn"`
+}
+
 type MonsterTypeLineSelectResult struct {
 	ID         int64 `db:"id" json:"id"`
 	OcgApiID   int64 `db:"ocg_api_id" json:"ocgApiID"`

--- a/code/cardApiCall/infoInsert/dto/kind/linkmarker.go
+++ b/code/cardApiCall/infoInsert/dto/kind/linkmarker.go
@@ -1,48 +1,29 @@
 package kind
 
-import "slices"
+import "strings"
 
-type LinkMarker struct {
-	MarkerVal   int
-	DirectionEn string
+var linkMarkerMap = map[string]int32{
+	"top":          1,
+	"top-right":    2,
+	"right":        4,
+	"bottom-right": 8,
+	"bottom":       16,
+	"bottom-left":  32,
+	"left":         64,
+	"top-left":     128, // 標準表記は Top-Left にする（既存データとの整合は要確認）
 }
 
-var (
-	Top         = LinkMarker{MarkerVal: 1, DirectionEn: "Top"}
-	TopRight    = LinkMarker{MarkerVal: 2, DirectionEn: "Top-Right"}
-	Right       = LinkMarker{MarkerVal: 4, DirectionEn: "Right"}
-	BottomRight = LinkMarker{MarkerVal: 8, DirectionEn: "Bottom-Right"}
-	Bottom      = LinkMarker{MarkerVal: 16, DirectionEn: "Bottom"}
-	BottomLeft  = LinkMarker{MarkerVal: 32, DirectionEn: "Bottom-Left"}
-	Left        = LinkMarker{MarkerVal: 64, DirectionEn: "Left"}
-	LeftTop     = LinkMarker{MarkerVal: 128, DirectionEn: "Left-Top"}
-)
-
-func ConvertLinkMarkerStringToLinkMarker(linkMarkerStringList []string) int {
-	result := 0
-	if slices.Contains(linkMarkerStringList, Top.DirectionEn) {
-		result += Top.MarkerVal
+// ConvertLinkMarkerStringToLinkMarker は方向文字列リストをマスク(int32)に変換する。
+// 受け取る文字列は小文字化してハイフン区切りで正規化する（例: "Top-Right" -> "top-right"）。
+func ConvertLinkMarkerStringToLinkMarkerValInt(linkMarkerStringList []string) int32 {
+	var mask int32
+	for _, s := range linkMarkerStringList {
+		key := strings.ToLower(strings.TrimSpace(s))
+		// 正規化: "top-right" / "top right" / "Top-Right" 等を許容したければここで置換する
+		key = strings.ReplaceAll(key, " ", "-")
+		if v, ok := linkMarkerMap[key]; ok {
+			mask |= v
+		}
 	}
-	if slices.Contains(linkMarkerStringList, TopRight.DirectionEn) {
-		result += TopRight.MarkerVal
-	}
-	if slices.Contains(linkMarkerStringList, Right.DirectionEn) {
-		result += Right.MarkerVal
-	}
-	if slices.Contains(linkMarkerStringList, BottomRight.DirectionEn) {
-		result += BottomRight.MarkerVal
-	}
-	if slices.Contains(linkMarkerStringList, Bottom.DirectionEn) {
-		result += Bottom.MarkerVal
-	}
-	if slices.Contains(linkMarkerStringList, BottomLeft.DirectionEn) {
-		result += BottomLeft.MarkerVal
-	}
-	if slices.Contains(linkMarkerStringList, Left.DirectionEn) {
-		result += Left.MarkerVal
-	}
-	if slices.Contains(linkMarkerStringList, LeftTop.DirectionEn) {
-		result += LeftTop.MarkerVal
-	}
-	return result
+	return mask
 }

--- a/code/cardApiCall/infoInsert/dto/kind/linkmarker.go
+++ b/code/cardApiCall/infoInsert/dto/kind/linkmarker.go
@@ -1,0 +1,48 @@
+package kind
+
+import "slices"
+
+type LinkMarker struct {
+	MarkerVal   int
+	DirectionEn string
+}
+
+var (
+	Top         = LinkMarker{MarkerVal: 1, DirectionEn: "Top"}
+	TopRight    = LinkMarker{MarkerVal: 2, DirectionEn: "Top-Right"}
+	Right       = LinkMarker{MarkerVal: 4, DirectionEn: "Right"}
+	BottomRight = LinkMarker{MarkerVal: 8, DirectionEn: "Bottom-Right"}
+	Bottom      = LinkMarker{MarkerVal: 16, DirectionEn: "Bottom"}
+	BottomLeft  = LinkMarker{MarkerVal: 32, DirectionEn: "Bottom-Left"}
+	Left        = LinkMarker{MarkerVal: 64, DirectionEn: "Left"}
+	LeftTop     = LinkMarker{MarkerVal: 128, DirectionEn: "Left-Top"}
+)
+
+func ConvertLinkMarkerStringToLinkMarker(linkMarkerStringList []string) int {
+	result := 0
+	if slices.Contains(linkMarkerStringList, Top.DirectionEn) {
+		result += Top.MarkerVal
+	}
+	if slices.Contains(linkMarkerStringList, TopRight.DirectionEn) {
+		result += TopRight.MarkerVal
+	}
+	if slices.Contains(linkMarkerStringList, Right.DirectionEn) {
+		result += Right.MarkerVal
+	}
+	if slices.Contains(linkMarkerStringList, BottomRight.DirectionEn) {
+		result += BottomRight.MarkerVal
+	}
+	if slices.Contains(linkMarkerStringList, Bottom.DirectionEn) {
+		result += Bottom.MarkerVal
+	}
+	if slices.Contains(linkMarkerStringList, BottomLeft.DirectionEn) {
+		result += BottomLeft.MarkerVal
+	}
+	if slices.Contains(linkMarkerStringList, Left.DirectionEn) {
+		result += Left.MarkerVal
+	}
+	if slices.Contains(linkMarkerStringList, LeftTop.DirectionEn) {
+		result += LeftTop.MarkerVal
+	}
+	return result
+}

--- a/code/cardApiCall/infoInsert/usecase/neon/neon_base.go
+++ b/code/cardApiCall/infoInsert/usecase/neon/neon_base.go
@@ -22,6 +22,7 @@ type NeonUseCase interface {
 	GetSpellCardByID(ctx context.Context, cardID int64) (cardrecord.SpellCardSelectResult, error)
 	InsertMonsterCardInfo(ctx context.Context, cardInfo cardrecord.StandardCard) (int64, error)
 	GetMonsterCardByID(ctx context.Context, cardID int64) (cardrecord.MonsterCardSelectResult, error)
+	GetMonsterCardExtendedByID(ctx context.Context, cardID int64) (cardrecord.MonsterCardSelectResultExtended, error)
 	GetMonsterTypeLinesEnByCardID(ctx context.Context, cardID int64) ([]string, error)
 }
 

--- a/code/cardApiCall/infoInsert/usecase/neon/neon_monster.go
+++ b/code/cardApiCall/infoInsert/usecase/neon/neon_monster.go
@@ -142,7 +142,8 @@ func (n *neonUseCaseImpl) GetMonsterCardByID(ctx context.Context, cardID int64) 
 
 // GetMonsterCardExtendedByID は、拡張属性(リンクマーカーの向きやペンデュラムスケールなど)付きでモンスターのカードを取得。
 func (n *neonUseCaseImpl) GetMonsterCardExtendedByID(ctx context.Context, cardID int64) (cardrecord.MonsterCardSelectResultExtended, error) {
-	monsterRepo := repository.NewMonsterRepository(sqlc_gen.New(n.ProduceConnDB()))
+	q := sqlc_gen.New(n.ProduceConnDB())
+	monsterRepo := repository.NewMonsterRepository(q)
 	monster, err := monsterRepo.GetMonsterByCardID(ctx, cardID)
 	if err != nil {
 		return cardrecord.MonsterCardSelectResultExtended{}, err
@@ -154,7 +155,7 @@ func (n *neonUseCaseImpl) GetMonsterCardExtendedByID(ctx context.Context, cardID
 	}
 
 	if monsterWithTypeLines.IsLink {
-		linkMonsterRepo := repository.NewLinkMonsterRepository(sqlc_gen.New(n.ProduceConnDB()))
+		linkMonsterRepo := repository.NewLinkMonsterRepository(q)
 		linkMonster, err := linkMonsterRepo.GetLinkMonsterByCardID(ctx, cardID)
 		if err != nil {
 			return cardrecord.MonsterCardSelectResultExtended{}, err
@@ -167,7 +168,7 @@ func (n *neonUseCaseImpl) GetMonsterCardExtendedByID(ctx context.Context, cardID
 	}
 
 	if monsterWithTypeLines.IsPendulum {
-		pendulumMonsterRepo := repository.NewPendulumMonsterRepository(sqlc_gen.New(n.ProduceConnDB()))
+		pendulumMonsterRepo := repository.NewPendulumMonsterRepository(q)
 		pendulumMonster, err := pendulumMonsterRepo.GetPendulumMonsterByCardID(ctx, cardID)
 		if err != nil {
 			return cardrecord.MonsterCardSelectResultExtended{}, err
@@ -188,6 +189,7 @@ func (n *neonUseCaseImpl) GetMonsterCardExtendedByID(ctx context.Context, cardID
 
 // GetMonsterTypeLinesEnByCardID は、モンスターの種類を取得。
 func (n *neonUseCaseImpl) GetMonsterTypeLinesEnByCardID(ctx context.Context, cardID int64) ([]string, error) {
+
 	monsterRepo := repository.NewMonsterRepository(sqlc_gen.New(n.ProduceConnDB()))
 	typeLineNames := []string{}
 	typeLineSelectResult, err := monsterRepo.GetMonsterTypeLineByCardID(ctx, cardID)

--- a/code/cardApiCall/infoInsert/usecase/neon/neon_monster.go
+++ b/code/cardApiCall/infoInsert/usecase/neon/neon_monster.go
@@ -121,7 +121,7 @@ func (n *neonUseCaseImpl) InsertMonsterCardInfo(ctx context.Context, cardInfo ca
 		// モンスターの種類がLinkの場合は、Linkテーブルへの挿入
 		if slices.Contains(cardInfo.TypeLines, "Link") {
 			// Linkマーカーに変換する処理が必要な気がする
-			_, err = linkMonsterRepo.InsertLinkMonster(ctx, card.ID, int32(kind.ConvertLinkMarkerStringToLinkMarkerValInt(cardInfo.LinkMarkers)))
+			_, err = linkMonsterRepo.InsertLinkMonster(ctx, card.ID, kind.ConvertLinkMarkerStringToLinkMarkerValInt(cardInfo.LinkMarkers))
 			if err != nil {
 				return fmt.Errorf("error create link monster %w", err)
 			}

--- a/code/cardApiCall/infoInsert/usecase/neon/neon_monster.go
+++ b/code/cardApiCall/infoInsert/usecase/neon/neon_monster.go
@@ -121,7 +121,7 @@ func (n *neonUseCaseImpl) InsertMonsterCardInfo(ctx context.Context, cardInfo ca
 		// モンスターの種類がLinkの場合は、Linkテーブルへの挿入
 		if slices.Contains(cardInfo.TypeLines, "Link") {
 			// Linkマーカーに変換する処理が必要な気がする
-			_, err = linkMonsterRepo.InsertLinkMonster(ctx, card.ID, int32(kind.ConvertLinkMarkerStringToLinkMarker(cardInfo.LinkMarkers)))
+			_, err = linkMonsterRepo.InsertLinkMonster(ctx, card.ID, int32(kind.ConvertLinkMarkerStringToLinkMarkerValInt(cardInfo.LinkMarkers)))
 			if err != nil {
 				return fmt.Errorf("error create link monster %w", err)
 			}

--- a/code/cardApiCall/infoInsert/usecase/neon/neon_monster_test.go
+++ b/code/cardApiCall/infoInsert/usecase/neon/neon_monster_test.go
@@ -3,6 +3,7 @@ package neon_test
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 
 	"atomisu.com/ocg-statics/infoInsert/app"
@@ -13,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func testMonsterCommon(t *testing.T, sampleData cardrecord.StandardCard, attrNameJa string, raceNameJa string, typeLines []string) (cardrecord.MonsterCardSelectResult, error) {
+func testMonsterCommon(t *testing.T, sampleData cardrecord.StandardCard, attrNameJa string, raceNameJa string, typeLines []string, linkValInt int32) (cardrecord.MonsterCardSelectResult, error) {
 	config.BeforeEachForUnitTest()      // テスト前処理
 	defer config.AfterEachForUnitTest() // テスト後処理
 
@@ -29,7 +30,9 @@ func testMonsterCommon(t *testing.T, sampleData cardrecord.StandardCard, attrNam
 	assert.NotEqual(t, int32(-1), resultInsert)
 	cardID := resultInsert
 
-	resultsGet, err := neonUseCase.GetMonsterCardByID(context.Background(), cardID)
+	resultsFull, err := neonUseCase.GetMonsterCardExtendedByID(context.Background(), cardID)
+	resultsGet := resultsFull.MonsterCardSelectResult
+
 	assert.NoError(t, err)
 	assert.NotNil(t, resultsGet)
 	assert.Equal(t, sampleData.NameEn, resultsGet.NameEn)
@@ -42,7 +45,12 @@ func testMonsterCommon(t *testing.T, sampleData cardrecord.StandardCard, attrNam
 	assert.Equal(t, attrNameJa, resultsGet.AttributeNameJa)
 	assert.Equal(t, sampleData.Def, resultsGet.Defense)
 	assert.Equal(t, sampleData.Atk, resultsGet.Attack)
-	assert.Equal(t, sampleData.Level, resultsGet.Level)
+	assert.Equal(t, slices.Max([]int32{sampleData.Level, sampleData.LinkVal}), resultsGet.Level)
+
+	assert.Equal(t, linkValInt, resultsFull.LinkMarker)
+	assert.Equal(t, sampleData.PendulumScale, resultsFull.Scale)
+	assert.Equal(t, sampleData.PendulumTextJa, resultsFull.PendulumTextJa)
+	assert.Equal(t, sampleData.PendulumTextEn, resultsFull.PendulumTextEn)
 
 	typeLinesEn, err := neonUseCase.GetMonsterTypeLinesEnByCardID(context.Background(), cardID)
 	assert.NoError(t, err)
@@ -79,7 +87,7 @@ func TestNeonMonsterUseCase(t *testing.T) {
 		RaceNameJa := "天使族"
 		TypeLines := []string{"Normal"}
 
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 
@@ -110,7 +118,7 @@ func TestNeonMonsterUseCase(t *testing.T) {
 		AttributeNameJa := "地"
 		RaceNameJa := "獣族"
 		TypeLines := []string{"Normal"}
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -140,7 +148,7 @@ func TestNeonMonsterUseCase(t *testing.T) {
 		AttributeNameJa := "光"
 		RaceNameJa := "炎族"
 		TypeLines := []string{"Effect"}
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -170,7 +178,7 @@ func TestNeonMonsterUseCase(t *testing.T) {
 		AttributeNameJa := "光"
 		RaceNameJa := "戦士族"
 		TypeLines := []string{"Gemini", "Effect"}
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -200,7 +208,7 @@ func TestNeonMonsterUseCase(t *testing.T) {
 		AttributeNameJa := "闇"
 		RaceNameJa := "機械族"
 		TypeLines := []string{"Toon", "Effect"}
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -230,7 +238,7 @@ func TestNeonMonsterUseCase(t *testing.T) {
 		AttributeNameJa := "風"
 		RaceNameJa := "幻竜族"
 		TypeLines := []string{"Tuner", "Effect"}
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -259,7 +267,7 @@ func TestNeonMonsterUseCase(t *testing.T) {
 		AttributeNameJa := "風"
 		RaceNameJa := "天使族"
 		TypeLines := []string{"Union", "Effect"}
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -289,7 +297,7 @@ func TestNeonMonsterUseCase(t *testing.T) {
 		AttributeNameJa := "地"
 		RaceNameJa := "岩石族"
 		TypeLines := []string{"Flip", "Effect"}
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -319,7 +327,7 @@ func TestNeonMonsterUseCase(t *testing.T) {
 		AttributeNameJa := "闇"
 		RaceNameJa := "魔法使い族"
 		TypeLines := []string{"Flip", "Tuner", "Effect"}
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -348,7 +356,7 @@ func TestNeonMonsterUseCase(t *testing.T) {
 		AttributeNameJa := "地"
 		RaceNameJa := "アンデット族"
 		TypeLines := []string{"Spirit", "Effect"}
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -382,7 +390,7 @@ func TestNeonMonsterUseCase2(t *testing.T) {
 		AttributeNameJa := "地"
 		RaceNameJa := "戦士族"
 		TypeLines := []string{"Fusion"}
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -411,7 +419,7 @@ func TestNeonMonsterUseCase2(t *testing.T) {
 		AttributeNameJa := "闇"
 		RaceNameJa := "幻想魔族"
 		TypeLines := []string{"Fusion", "Effect"}
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -440,7 +448,7 @@ func TestNeonMonsterUseCase2(t *testing.T) {
 		AttributeNameJa := "水"
 		RaceNameJa := "水族"
 		TypeLines := []string{"Ritual"}
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -470,7 +478,7 @@ func TestNeonMonsterUseCase2(t *testing.T) {
 		AttributeNameJa := "水"
 		RaceNameJa := "サイバース族"
 		TypeLines := []string{"Ritual", "Effect"}
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -500,7 +508,7 @@ func TestNeonMonsterUseCase2(t *testing.T) {
 		AttributeNameJa := "地"
 		RaceNameJa := "岩石族"
 		TypeLines := []string{"Xyz"}
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -529,7 +537,7 @@ func TestNeonMonsterUseCase2(t *testing.T) {
 		AttributeNameJa := "闇"
 		RaceNameJa := "雷族"
 		TypeLines := []string{"Xyz", "Effect"}
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -558,7 +566,7 @@ func TestNeonMonsterUseCase2(t *testing.T) {
 		AttributeNameJa := "地"
 		RaceNameJa := "悪魔族"
 		TypeLines := []string{"Synchro"}
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -587,7 +595,7 @@ func TestNeonMonsterUseCase2(t *testing.T) {
 		AttributeNameJa := "風"
 		RaceNameJa := "海竜族"
 		TypeLines := []string{"Synchro", "Effect"}
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -620,7 +628,7 @@ func TestNeonMonsterUseCase2(t *testing.T) {
 		fmt.Println(AttributeNameJa)
 		fmt.Println(RaceNameJa)
 		fmt.Println(TypeLines)
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -654,7 +662,7 @@ func TestNeonMonsterUseCase3(t *testing.T) {
 		RaceNameJa := "鳥獣族"
 		TypeLines := []string{"Normal", "Pendulum"}
 
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -685,7 +693,7 @@ func TestNeonMonsterUseCase3(t *testing.T) {
 		RaceNameJa := "ドラゴン族"
 		TypeLines := []string{"Pendulum", "Effect"}
 
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -715,7 +723,7 @@ func TestNeonMonsterUseCase3(t *testing.T) {
 		RaceNameJa := "ドラゴン族"
 		TypeLines := []string{"Fusion", "Pendulum", "Effect"}
 
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -746,7 +754,7 @@ func TestNeonMonsterUseCase3(t *testing.T) {
 		RaceNameJa := "悪魔族"
 		TypeLines := []string{"Xyz", "Pendulum", "Effect"}
 
-		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, results)
 	})
@@ -779,13 +787,11 @@ func TestNeonMonsterUseCase4(t *testing.T) {
 		AttributeNameJa := "光"
 		RaceNameJa := "サイバース族"
 		TypeLines := []string{"Link"}
-		fmt.Println(sampleData)
-		fmt.Println(AttributeNameJa)
-		fmt.Println(RaceNameJa)
-		fmt.Println(TypeLines)
-		//results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
-		//assert.NoError(t, err)
-		//assert.NotNil(t, results)
+		LinkValInt := int32(40)
+
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, LinkValInt)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
 	})
 
 	t.Run("カード情報の挿入&取得テスト（リンク）", func(t *testing.T) {
@@ -813,12 +819,10 @@ func TestNeonMonsterUseCase4(t *testing.T) {
 		AttributeNameJa := "地"
 		RaceNameJa := "昆虫族"
 		TypeLines := []string{"Link", "Effect"}
-		fmt.Println(sampleData)
-		fmt.Println(AttributeNameJa)
-		fmt.Println(RaceNameJa)
-		fmt.Println(TypeLines)
-		//results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines)
-		//assert.NoError(t, err)
-		//assert.NotNil(t, results)
+		LinkValInt := int32(84)
+
+		results, err := testMonsterCommon(t, sampleData, AttributeNameJa, RaceNameJa, TypeLines, LinkValInt)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
 	})
 }


### PR DESCRIPTION
- Linkmarkerに関するstructをkindの中に準備
- 拡張属性を持つモンスターカードに対するテストを拡充
- 拡張属性付きでモンスター情報を取得できるようにuseCaseのメソッドを追加
- Linkモンスターに関するテストを解放
- LinkMonsterを適切にInsertできるように機能を追加