### PR TITLE
【カ】【L】【データINSERT用】【All】汎用修正 #113

### DIFF
--- a/code/cardApiCall/infoInsert/http/tcg.go
+++ b/code/cardApiCall/infoInsert/http/tcg.go
@@ -22,9 +22,11 @@ type TcgRest interface {
 
 // NewTCGRest is a constructor for TcgRest.
 func NewTCGRest() TcgRest {
+	logger, _ := zap.NewDevelopment()
+
 	return NewRest(func(r *restImpl) TcgRest {
 		return &tcgRestImpl{restImpl: r}
-	}, zap.NewExample())
+	}, logger)
 }
 
 // GetEnInfoByName is a method to get the English information of a card by name.

--- a/code/cardApiCall/infoInsert/usecase/neon/neon_card.go
+++ b/code/cardApiCall/infoInsert/usecase/neon/neon_card.go
@@ -3,14 +3,13 @@ package neon
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 
 	"atomisu.com/ocg-statics/infoInsert/dto/cardrecord"
 )
 
 func isMonsterCard(cardInfo cardrecord.StandardCard) bool {
-	return slices.Contains(cardInfo.TypeLines, "Monster")
+	return strings.Contains(cardInfo.Type, "Monster")
 }
 
 func isTrapCard(cardInfo cardrecord.StandardCard) bool {

--- a/code/cardApiCall/infoInsert/usecase/tcgapi/tcg.go
+++ b/code/cardApiCall/infoInsert/usecase/tcgapi/tcg.go
@@ -22,8 +22,9 @@ type TcgApiCard struct {
 	LinkMarkers           []string `json:"linkMarkers"`
 	Attribute             string   `json:"attribute"`
 	LinkVal               int32    `json:"linkVal"`
-	TypeLines             []string `json:"typeLines"`
+	TypeLines             []string `json:"typeline"`
 	HumanReadableCardType string   `json:"humanReadableCardType"`
+	Scale                 int32    `json:"scale"`
 	PendulumText          string   `json:"pendulumText"`
 }
 


### PR DESCRIPTION
- Loggerの統一
- TcgApiCardの定義を修正
- neon_cardユースケースにおけるモンスターカードの判定ロジックを修正