### PR TITLE
【カ】【L】【データINSERT用】【All】CardIDからカード種別を判定するロジックの作成 #106

### DIFF
--- a/code/cardApiCall/infoInsert/dto/cardrecord/carddto.go
+++ b/code/cardApiCall/infoInsert/dto/cardrecord/carddto.go
@@ -101,3 +101,23 @@ type TcgApiCard struct {
 	Scale                 int32    `json:"scale"`
 	PendulumText          string   `json:"pendulumText"`
 }
+
+type CardPatternSelectResult struct {
+	CardID    int64 `db:"card_id" json:"cardId"`
+	NeuronID  int64 `db:"neuron_id" json:"neuronId"`
+	OcgApiID  int64 `db:"ocg_api_id" json:"ocgApiId"`
+	IsMonster bool  `db:"is_monster" json:"isMonster"`
+	IsSpell   bool  `db:"is_spell" json:"isSpell"`
+	IsTrap    bool  `db:"is_trap" json:"isTrap"`
+}
+
+func (c *CardPatternSelectResult) FromSelectCardPatternByCardIDRow(row sqlc_gen.SelectCardPatternByCardIDRow) *CardPatternSelectResult {
+	return &CardPatternSelectResult{
+		CardID:    row.CardID,
+		NeuronID:  row.NeuronID.Int64,
+		OcgApiID:  row.OcgApiID.Int64,
+		IsMonster: row.IsMonster,
+		IsSpell:   row.IsSpell,
+		IsTrap:    row.IsTrap,
+	}
+}

--- a/code/cardApiCall/infoInsert/repository/card.go
+++ b/code/cardApiCall/infoInsert/repository/card.go
@@ -15,6 +15,7 @@ type CardRepository interface {
 	InsertCard(ctx context.Context, arg sqlc_gen.InsertCardParams) (sqlc_gen.Card, error)
 	GetCardByNameEn(ctx context.Context, nameEn string) (sqlc_gen.Card, error)
 	GetCardByNameJa(ctx context.Context, nameJa string) (sqlc_gen.Card, error)
+	GetCardPatternByCardID(ctx context.Context, cardId int64) (sqlc_gen.SelectCardPatternByCardIDRow, error)
 }
 
 type cardRepositoryImpl struct {
@@ -86,4 +87,18 @@ func (r *cardRepositoryImpl) GetCardByNameJa(ctx context.Context, nameJa string)
 
 	r.logDBResult("GetCardByNameJa", card, zap.String("name_ja", nameJa))
 	return card, nil
+}
+
+func (r *cardRepositoryImpl) GetCardPatternByCardID(ctx context.Context, cardId int64) (sqlc_gen.SelectCardPatternByCardIDRow, error) {
+	start := time.Now()
+	defer r.logDBOperation("GetCardPatternByCardID", start, zap.Int64("card_id", cardId))
+
+	cardPattern, err := r.queries.SelectCardPatternByCardID(ctx, cardId)
+	if err != nil {
+		r.logDBError("GetCardPatternByCardID", err, zap.Int64("card_id", cardId))
+		return sqlc_gen.SelectCardPatternByCardIDRow{}, err
+	}
+
+	r.logDBResult("GetCardPatternByCardID", cardPattern, zap.Int64("card_id", cardId))
+	return cardPattern, nil
 }

--- a/code/cardApiCall/infoInsert/repository/card_test.go
+++ b/code/cardApiCall/infoInsert/repository/card_test.go
@@ -64,3 +64,149 @@ func TestForCardInsert(t *testing.T) {
 		assert.Equal(t, inserData.OcgApiID.Int64, card.OcgApiID.Int64)
 	})
 }
+
+func TestForCardPatternByCardID(t *testing.T) {
+	t.Run("正常系01 モンスターカード", func(t *testing.T) {
+		config.BeforeEachForUnitTest()      // テスト前処理
+		defer config.AfterEachForUnitTest() // テスト後処理
+		injector := do.New()
+		do.Provide(injector, config.TestDbConnection)
+
+		insertCardData := sqlc_gen.InsertCardParams{
+			NameEn:     sql.NullString{String: "Test Card", Valid: true},
+			NameJa:     sql.NullString{String: "テストカード", Valid: true},
+			CardTextJa: sql.NullString{String: "テストカードの説明", Valid: true},
+			CardTextEn: sql.NullString{String: "Test Card Description", Valid: true},
+			NeuronID:   sql.NullInt64{Int64: 1, Valid: true},
+			OcgApiID:   sql.NullInt64{Int64: 1, Valid: true},
+		}
+
+		dbConn := do.MustInvoke[*config.DbConn](injector)
+		ctx := context.Background()
+		q := sqlc_gen.New(dbConn)
+		repoCard := repository.NewCardRepository(q)
+		card, err := repoCard.InsertCard(ctx, insertCardData)
+		assert.NoError(t, err)
+
+		repoMonster := repository.NewMonsterRepository(q)
+		testCardID := card.ID
+		testRaceID := int32(1)
+		testAttributeID := int32(1)
+		testAttack := int32(1000)
+		testDefense := int32(500)
+		testLevel := int32(4)
+		testTypeIDs := []int32{1, 2}
+
+		monster, err := repoMonster.InsertMonster(ctx, testCardID, testRaceID, testAttributeID, testAttack, testDefense, testLevel, testTypeIDs)
+		assert.NoError(t, err)
+
+		cardPattern, err := repoCard.GetCardPatternByCardID(ctx, monster.CardID)
+		assert.NoError(t, err)
+		assert.Equal(t, testCardID, cardPattern.CardID)
+		assert.Equal(t, insertCardData.NeuronID.Int64, cardPattern.NeuronID.Int64)
+		assert.Equal(t, insertCardData.OcgApiID.Int64, cardPattern.OcgApiID.Int64)
+		assert.True(t, cardPattern.IsMonster)
+		assert.False(t, cardPattern.IsSpell)
+		assert.False(t, cardPattern.IsTrap)
+	})
+
+	t.Run("正常系02 魔法カード", func(t *testing.T) {
+		config.BeforeEachForUnitTest()      // テスト前処理
+		defer config.AfterEachForUnitTest() // テスト後処理
+		injector := do.New()
+		do.Provide(injector, config.TestDbConnection)
+
+		insertCardData := sqlc_gen.InsertCardParams{
+			NameEn:     sql.NullString{String: "Test Spell Card", Valid: true},
+			NameJa:     sql.NullString{String: "テスト魔法カード", Valid: true},
+			CardTextJa: sql.NullString{String: "テスト魔法カードの説明", Valid: true},
+			CardTextEn: sql.NullString{String: "Test Spell Card Description", Valid: true},
+			NeuronID:   sql.NullInt64{Int64: 2, Valid: true},
+			OcgApiID:   sql.NullInt64{Int64: 2, Valid: true},
+		}
+
+		dbConn := do.MustInvoke[*config.DbConn](injector)
+		ctx := context.Background()
+		q := sqlc_gen.New(dbConn)
+		repoCard := repository.NewCardRepository(q)
+		card, err := repoCard.InsertCard(ctx, insertCardData)
+		assert.NoError(t, err)
+
+		repoSpell := repository.NewSpellRepository(q)
+		testCardID := card.ID
+		testSpellTypeID := int32(1)
+
+		spell, err := repoSpell.InsertSpell(ctx, testCardID, testSpellTypeID)
+		assert.NoError(t, err)
+
+		cardPattern, err := repoCard.GetCardPatternByCardID(ctx, spell.CardID)
+		assert.NoError(t, err)
+		assert.Equal(t, testCardID, cardPattern.CardID)
+		assert.Equal(t, insertCardData.NeuronID.Int64, cardPattern.NeuronID.Int64)
+		assert.Equal(t, insertCardData.OcgApiID.Int64, cardPattern.OcgApiID.Int64)
+		assert.False(t, cardPattern.IsMonster)
+		assert.True(t, cardPattern.IsSpell)
+		assert.False(t, cardPattern.IsTrap)
+	})
+
+	t.Run("正常系03 罠カード", func(t *testing.T) {
+		config.BeforeEachForUnitTest()      // テスト前処理
+		defer config.AfterEachForUnitTest() // テスト後処理
+		injector := do.New()
+		do.Provide(injector, config.TestDbConnection)
+
+		insertCardData := sqlc_gen.InsertCardParams{
+			NameEn:     sql.NullString{String: "Test Trap Card", Valid: true},
+			NameJa:     sql.NullString{String: "テスト罠カード", Valid: true},
+			CardTextJa: sql.NullString{String: "テスト罠カードの説明", Valid: true},
+			CardTextEn: sql.NullString{String: "Test Trap Card Description", Valid: true},
+			NeuronID:   sql.NullInt64{Int64: 3, Valid: true},
+			OcgApiID:   sql.NullInt64{Int64: 3, Valid: true},
+		}
+
+		dbConn := do.MustInvoke[*config.DbConn](injector)
+		ctx := context.Background()
+		q := sqlc_gen.New(dbConn)
+		repoCard := repository.NewCardRepository(q)
+		card, err := repoCard.InsertCard(ctx, insertCardData)
+		assert.NoError(t, err)
+
+		repoTrap := repository.NewTrapRepository(q)
+		testCardID := card.ID
+		testTrapTypeID := int32(1)
+
+		trap, err := repoTrap.InsertTrap(ctx, testCardID, testTrapTypeID)
+		assert.NoError(t, err)
+
+		cardPattern, err := repoCard.GetCardPatternByCardID(ctx, trap.CardID)
+		assert.NoError(t, err)
+		assert.Equal(t, testCardID, cardPattern.CardID)
+		assert.Equal(t, insertCardData.NeuronID.Int64, cardPattern.NeuronID.Int64)
+		assert.Equal(t, insertCardData.OcgApiID.Int64, cardPattern.OcgApiID.Int64)
+		assert.False(t, cardPattern.IsMonster)
+		assert.False(t, cardPattern.IsSpell)
+		assert.True(t, cardPattern.IsTrap)
+	})
+
+	t.Run("正常系04 存在しないカードID", func(t *testing.T) {
+		config.BeforeEachForUnitTest()      // テスト前処理
+		defer config.AfterEachForUnitTest() // テスト後処理
+		injector := do.New()
+		do.Provide(injector, config.TestDbConnection)
+
+		dbConn := do.MustInvoke[*config.DbConn](injector)
+		ctx := context.Background()
+		q := sqlc_gen.New(dbConn)
+		repoCard := repository.NewCardRepository(q)
+
+		testID := int64(999)
+		cardPattern, err := repoCard.GetCardPatternByCardID(ctx, testID)
+		assert.NoError(t, err)
+		assert.Equal(t, testID, cardPattern.CardID)
+		assert.False(t, cardPattern.NeuronID.Valid)
+		assert.False(t, cardPattern.OcgApiID.Valid)
+		assert.False(t, cardPattern.IsMonster)
+		assert.False(t, cardPattern.IsSpell)
+		assert.False(t, cardPattern.IsTrap)
+	})
+}

--- a/code/cardApiCall/infoInsert/sqlc/queries/card.sql
+++ b/code/cardApiCall/infoInsert/sqlc/queries/card.sql
@@ -48,3 +48,20 @@ WHERE name_en = $1;
 -- name: SelectByCardNameJa :one
 SELECT * FROM cards
 WHERE name_ja = $1;
+
+-- name: SelectCardPatternByCardID :one
+WITH dummy AS (
+    SELECT $1::bigint as id
+)
+SELECT
+    dummy.id as card_id
+    ,card.neuron_id
+    ,card.ocg_api_id
+    ,exists (select 1 from monsters where monsters.card_id = dummy.id) as is_monster
+    ,exists (select 1 from spells where spells.card_id = dummy.id) as is_spell
+    ,exists (select 1 from traps where traps.card_id = dummy.id) as is_trap
+FROM
+    dummy
+LEFT JOIN
+    cards AS card
+    ON card.id = dummy.id;

--- a/code/cardApiCall/infoInsert/usecase/neon/neon_base.go
+++ b/code/cardApiCall/infoInsert/usecase/neon/neon_base.go
@@ -25,6 +25,7 @@ type NeonUseCase interface {
 	GetMonsterCardExtendedByID(ctx context.Context, cardID int64) (cardrecord.MonsterCardSelectResultExtended, error)
 	GetMonsterTypeLinesEnByCardID(ctx context.Context, cardID int64) ([]string, error)
 	InsertCardInfo(ctx context.Context, cardInfo cardrecord.StandardCard) (int64, error)
+	GetCardPatternByCardID(ctx context.Context, cardID int64) (cardrecord.CardPatternSelectResult, error)
 }
 
 // NewNeonUseCase は、NeonUseCaseのコンストラクタです。

--- a/code/cardApiCall/infoInsert/usecase/neon/neon_card.go
+++ b/code/cardApiCall/infoInsert/usecase/neon/neon_card.go
@@ -11,27 +11,27 @@ import (
 	"atomisu.com/ocg-statics/infoInsert/transaction"
 )
 
-func isMonsterCardWithStandardCard(cardInfo cardrecord.StandardCard) bool {
+func checkStandardCardIsMonster(cardInfo cardrecord.StandardCard) bool {
 	return strings.Contains(cardInfo.Type, "Monster")
 }
 
-func isTrapCardWithStandardCard(cardInfo cardrecord.StandardCard) bool {
+func checkStandardCardIsTrap(cardInfo cardrecord.StandardCard) bool {
 	return strings.Contains(cardInfo.Type, "Trap")
 }
 
-func isSpellCardWithStandardCard(cardInfo cardrecord.StandardCard) bool {
+func checkStandardCardIsSpell(cardInfo cardrecord.StandardCard) bool {
 	return strings.Contains(cardInfo.Type, "Spell")
 }
 
 // StandardCardを引数として、魔法・罠・モンスターを判定して適切なテーブルに挿入する
 func (n *neonUseCaseImpl) InsertCardInfo(ctx context.Context, cardInfo cardrecord.StandardCard) (int64, error) {
-	if isMonsterCardWithStandardCard(cardInfo) {
+	if checkStandardCardIsMonster(cardInfo) {
 		return n.InsertMonsterCardInfo(ctx, cardInfo)
 	}
-	if isTrapCardWithStandardCard(cardInfo) {
+	if checkStandardCardIsTrap(cardInfo) {
 		return n.InsertTrapCardInfo(ctx, cardInfo)
 	}
-	if isSpellCardWithStandardCard(cardInfo) {
+	if checkStandardCardIsSpell(cardInfo) {
 		return n.InsertSpellCardInfo(ctx, cardInfo)
 	}
 	return 0, fmt.Errorf("invalid card type")
@@ -46,7 +46,7 @@ func (n *neonUseCaseImpl) GetCardPatternByCardID(ctx context.Context, cardID int
 		cardRepo := repository.NewCardRepository(q)
 		cardPattern, err := cardRepo.GetCardPatternByCardID(ctx, cardID)
 		if err != nil {
-			return fmt.Errorf("error get card pattern %w", err)
+			return fmt.Errorf("error get card pattern: %w", err)
 		}
 		result = *result.FromSelectCardPatternByCardIDRow(cardPattern)
 		return nil

--- a/code/cardApiCall/infoInsert/usecase/neon/neon_card.go
+++ b/code/cardApiCall/infoInsert/usecase/neon/neon_card.go
@@ -6,30 +6,50 @@ import (
 	"strings"
 
 	"atomisu.com/ocg-statics/infoInsert/dto/cardrecord"
+	"atomisu.com/ocg-statics/infoInsert/repository"
+	"atomisu.com/ocg-statics/infoInsert/sqlc_gen"
+	"atomisu.com/ocg-statics/infoInsert/transaction"
 )
 
-func isMonsterCard(cardInfo cardrecord.StandardCard) bool {
+func isMonsterCardWithStandardCard(cardInfo cardrecord.StandardCard) bool {
 	return strings.Contains(cardInfo.Type, "Monster")
 }
 
-func isTrapCard(cardInfo cardrecord.StandardCard) bool {
+func isTrapCardWithStandardCard(cardInfo cardrecord.StandardCard) bool {
 	return strings.Contains(cardInfo.Type, "Trap")
 }
 
-func isSpellCard(cardInfo cardrecord.StandardCard) bool {
+func isSpellCardWithStandardCard(cardInfo cardrecord.StandardCard) bool {
 	return strings.Contains(cardInfo.Type, "Spell")
 }
 
 // StandardCardを引数として、魔法・罠・モンスターを判定して適切なテーブルに挿入する
 func (n *neonUseCaseImpl) InsertCardInfo(ctx context.Context, cardInfo cardrecord.StandardCard) (int64, error) {
-	if isMonsterCard(cardInfo) {
+	if isMonsterCardWithStandardCard(cardInfo) {
 		return n.InsertMonsterCardInfo(ctx, cardInfo)
 	}
-	if isTrapCard(cardInfo) {
+	if isTrapCardWithStandardCard(cardInfo) {
 		return n.InsertTrapCardInfo(ctx, cardInfo)
 	}
-	if isSpellCard(cardInfo) {
+	if isSpellCardWithStandardCard(cardInfo) {
 		return n.InsertSpellCardInfo(ctx, cardInfo)
 	}
 	return 0, fmt.Errorf("invalid card type")
+}
+
+func (n *neonUseCaseImpl) GetCardPatternByCardID(ctx context.Context, cardID int64) (cardrecord.CardPatternSelectResult, error) {
+	tr := transaction.NewTx(n.ProduceConnDB())
+
+	result := cardrecord.CardPatternSelectResult{}
+
+	err := tr.ExecTx(ctx, func(q *sqlc_gen.Queries) error {
+		cardRepo := repository.NewCardRepository(q)
+		cardPattern, err := cardRepo.GetCardPatternByCardID(ctx, cardID)
+		if err != nil {
+			return fmt.Errorf("error get card pattern %w", err)
+		}
+		result = *result.FromSelectCardPatternByCardIDRow(cardPattern)
+		return nil
+	})
+	return result, err
 }

--- a/code/cardApiCall/infoInsert/usecase/neon/neon_card_test.go
+++ b/code/cardApiCall/infoInsert/usecase/neon/neon_card_test.go
@@ -23,19 +23,19 @@ func TestInsertCardInfo(t *testing.T) {
 
 		// isMonsterCardのロジック (TypeLinesに"Monster"が含まれる) を満たすようにテストデータを作成
 		sampleData := cardrecord.StandardCard{
-			NameEn:      "Mokey Mokey",
-			NameJa:      "もけもけ",
-			DescEn:      "An outcast angel.",
-			DescJa:      "天使のはみだし者",
-			NeuronID:    6018,
-			TcgID:       27288416,
-			Def:         100,
-			Atk:         300,
-			Type:        "Normal Monster",
-			Level:       1,
-			Race:        "Fairy",
-			Attribute:   "LIGHT",
-			TypeLines:   []string{"Monster", "Normal"}, // "Monster" を追加
+			NameEn:    "Mokey Mokey",
+			NameJa:    "もけもけ",
+			DescEn:    "An outcast angel.",
+			DescJa:    "天使のはみだし者",
+			NeuronID:  6018,
+			TcgID:     27288416,
+			Def:       100,
+			Atk:       300,
+			Type:      "Normal Monster",
+			Level:     1,
+			Race:      "Fairy",
+			Attribute: "LIGHT",
+			TypeLines: []string{"Monster", "Normal"}, // "Monster" を追加
 		}
 
 		cardID, err := neonUseCase.InsertCardInfo(context.Background(), sampleData)
@@ -58,6 +58,11 @@ func TestInsertCardInfo(t *testing.T) {
 		assert.Error(t, err) // Should be an error (not found)
 		_, err = neonUseCase.GetTrapCardByID(context.Background(), cardID)
 		assert.Error(t, err) // Should be an error (not found)
+
+		cardPattern, err := neonUseCase.GetCardPatternByCardID(context.Background(), cardID)
+		assert.True(t, cardPattern.IsMonster)
+		assert.False(t, cardPattern.IsSpell)
+		assert.False(t, cardPattern.IsTrap)
 	})
 
 	t.Run("魔法カードが正しく挿入される", func(t *testing.T) {
@@ -89,6 +94,11 @@ func TestInsertCardInfo(t *testing.T) {
 		assert.NotNil(t, result)
 		assert.Equal(t, sampleData.NameEn, result.NameEn)
 		assert.Equal(t, "通常", result.SpellTypeNameJa)
+
+		cardPattern, err := neonUseCase.GetCardPatternByCardID(context.Background(), cardID)
+		assert.False(t, cardPattern.IsMonster)
+		assert.True(t, cardPattern.IsSpell)
+		assert.False(t, cardPattern.IsTrap)
 
 		// 他のテーブルに挿入されていないことを確認
 		_, err = neonUseCase.GetMonsterCardExtendedByID(context.Background(), cardID)
@@ -132,6 +142,11 @@ func TestInsertCardInfo(t *testing.T) {
 		assert.Error(t, err) // Should be an error (not found)
 		_, err = neonUseCase.GetSpellCardByID(context.Background(), cardID)
 		assert.Error(t, err) // Should be an error (not found)
+
+		cardPattern, err := neonUseCase.GetCardPatternByCardID(context.Background(), cardID)
+		assert.False(t, cardPattern.IsMonster)
+		assert.False(t, cardPattern.IsSpell)
+		assert.True(t, cardPattern.IsTrap)
 	})
 
 	t.Run("無効なカードタイプはエラーを返す", func(t *testing.T) {
@@ -144,9 +159,9 @@ func TestInsertCardInfo(t *testing.T) {
 
 		// どのタイプにも一致しないデータ
 		sampleData := cardrecord.StandardCard{
-			NameEn:   "Invalid Card",
-			NameJa:   "無効なカード",
-			Type:     "Invalid Type",
+			NameEn:    "Invalid Card",
+			NameJa:    "無効なカード",
+			Type:      "Invalid Type",
 			TypeLines: []string{"Invalid"},
 		}
 


### PR DESCRIPTION
- ユースケースに（モンスター/罠/魔法）をIDから判定できるロジックを追加
- 既存実装されていたisMonsterCardについては、用途が不明瞭だったので、StandardCard引数から判断することを明記するために関数名を変更